### PR TITLE
Simplify MultiSelectInput

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,5 +4,5 @@ storybook-static
 .idea
 esm
 cjs
-index.d.ts
+/index.d.ts
 .storybook/dist

--- a/src/multiSelectInput/index.jsx
+++ b/src/multiSelectInput/index.jsx
@@ -24,7 +24,7 @@ const MultiSelectInput = (props) => {
         components={components}
         inputValue={props.inputValue}
         isClearable={props.isClearable}
-        isMulti={props.isMulti}
+        isMulti={true}
         menuIsOpen={false}
         onChange={props.handleChange}
         onInputChange={props.handleInputChange}

--- a/src/stories/form/multiselectinput.stories.jsx
+++ b/src/stories/form/multiselectinput.stories.jsx
@@ -31,7 +31,6 @@ export const multiSelectInput = (args) => {
     <CreatableContainer>
       <MultiSelectInput
         isClearable={args.isClearable}
-        isMulti={args.isMulti}
         error={args.error}
         inputValue={input}
         value={value}
@@ -45,7 +44,6 @@ export const multiSelectInput = (args) => {
 }
 
 multiSelectInput.args = {
-  isMulti: true,
   isClearable: true,
   error: false,
   placeholder: 'Enter input',
@@ -53,11 +51,6 @@ multiSelectInput.args = {
 
 multiSelectInput.argTypes = {
   isClearable: {
-    control: {
-      type: 'boolean',
-    },
-  },
-  isMulti: {
     control: {
       type: 'boolean',
     },

--- a/src/typings/index.d.ts
+++ b/src/typings/index.d.ts
@@ -1,4 +1,8 @@
-import { InputHTMLAttributes, TextareaHTMLAttributes } from 'react'
+import {
+  InputHTMLAttributes,
+  KeyboardEvent,
+  TextareaHTMLAttributes,
+} from 'react'
 import { EChartsOption } from 'echarts'
 
 export interface SelectValue {
@@ -190,8 +194,8 @@ interface LoaderProps {
 interface MultiSelectInputProps {
   handleChange: (value: SelectValue[]) => void
   handleInputChange: (inputValue: string) => void
-  handleKeyDown: (value: KeyboardEvent) => void
   inputValue: string | number
+  handleKeyDown: (event: KeyboardEvent) => void
   value: SelectValue[]
   className?: string
   error?: boolean

--- a/src/typings/index.d.ts
+++ b/src/typings/index.d.ts
@@ -188,9 +188,9 @@ interface LoaderProps {
 }
 
 interface MultiSelectInputProps {
-  handleChange: (value: SelectValue, type: string) => void
-  handleInputChange: (value: string) => void
-  handleKeyDown: (value: SelectValue) => void
+  handleChange: (value: SelectValue[]) => void
+  handleInputChange: (inputValue: string) => void
+  handleKeyDown: (value: KeyboardEvent) => void
   inputValue: string | number
   value: SelectValue[]
   className?: string

--- a/src/typings/index.d.ts
+++ b/src/typings/index.d.ts
@@ -196,7 +196,6 @@ interface MultiSelectInputProps {
   className?: string
   error?: boolean
   isClearable?: boolean
-  isMulti?: boolean
   minHeight?: number
   placeholder?: string
 }

--- a/src/typings/index.d.ts
+++ b/src/typings/index.d.ts
@@ -194,8 +194,8 @@ interface LoaderProps {
 interface MultiSelectInputProps {
   handleChange: (value: SelectValue[]) => void
   handleInputChange: (inputValue: string) => void
-  inputValue: string | number
   handleKeyDown: (event: KeyboardEvent) => void
+  inputValue: string
   value: SelectValue[]
   className?: string
   error?: boolean


### PR DESCRIPTION
This PR simplifies usage of MultiSelectInput:
* remove `isMulti` prop, have it always set to `true`
* fix type definitions

See type definitions from `react-select` for more info: [Creatable.js](https://github.com/JedWatson/react-select/blob/v4.3.1/packages/react-select/src/Creatable.js), [types.js](https://github.com/JedWatson/react-select/blob/v4.3.1/packages/react-select/src/types.js)